### PR TITLE
fixed: doubled placeholder translation in inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- doubled placeholder translation in inputs
 
 
 ## [2.3.0] - 2023-05-16

--- a/src/Render/NeoInputRenderer.php
+++ b/src/Render/NeoInputRenderer.php
@@ -14,6 +14,7 @@ use Nette\Forms\Controls\MultiSelectBox;
 use Nette\Forms\Controls\RadioList;
 use Nette\Forms\Controls\SelectBox;
 use Nette\Forms\Controls\TextArea;
+use Nette\Forms\Controls\TextBase;
 use Nette\Forms\Controls\UploadControl;
 use Nette\Localization\Translator;
 use Nette\Utils\Html;
@@ -67,7 +68,7 @@ class NeoInputRenderer
 
         $attrs = $control->attrs;
         unset($attrs['data-nette-rules']);
-        if (is_string($attrs['placeholder'] ?? null)) {
+        if (!($el instanceof TextBase) && is_string($attrs['placeholder'] ?? null)) {
             $attrs['placeholder'] = $this->translator->translate($attrs['placeholder']);
         }
         $attrs += array_filter($options, 'is_scalar');


### PR DESCRIPTION
placeholder is already translated in $el[TextInput/TextBase]->getControl()