### PR TITLE
Property FormCollectionItem::$name is deprecated, use FormCollectionI…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Property FormCollectionItem::$name is deprecated, use FormCollectionItem::getName() method
 
 
 ## [3.5.1] - 2026-01-12

--- a/src/Control/FormCollection.php
+++ b/src/Control/FormCollection.php
@@ -69,7 +69,7 @@ class FormCollection extends NeoContainer
         $this->prototype = $this->addCollectionItem('__prototype' . ++self::$prototypeIndex . '__', true);
         $this->formFactory?->__invoke($this->prototype);
         $this->addHidden(self::ORIGINAL_DATA, '{}');
-        NeoForm::addExcludedKeys(self::ORIGINAL_DATA, FormCollectionItem::UNIQID, $this->prototype->name);
+        NeoForm::addExcludedKeys(self::ORIGINAL_DATA, FormCollectionItem::UNIQID, $this->prototype->getName());
         return $this;
     }
 
@@ -117,7 +117,7 @@ class FormCollection extends NeoContainer
         $this->updateChildren();
         $this->removeComponent($this->prototype);
         parent::validate($controls);
-        $this->addComponent($this->prototype, $this->prototype->name);
+        $this->addComponent($this->prototype, $this->prototype->getName());
     }
 
     public function setValues($values, bool $erase = false, bool $onlyDisabled = false): static
@@ -323,7 +323,7 @@ class FormCollection extends NeoContainer
     {
         $this->removeComponent($this->prototype);
         $values = parent::getUntrustedValues($returnType, $controls);
-        $this->addComponent($this->prototype, $this->prototype->name);
+        $this->addComponent($this->prototype, $this->prototype->getName());
         return $values;
     }
 


### PR DESCRIPTION
Fixed error `Property FormCollectionItem::$name is deprecated, use FormCollectionItem::getName() method`...