### PR TITLE
Fix PHPStan level 8 errors and add CI

### DIFF
--- a/.github/phpstan/composer.json
+++ b/.github/phpstan/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "efabrica/neoforms-ci-tools",
+    "description": "Isolated static analysis tooling for CI, kept out of the library's own composer.json to avoid dependency conflicts",
+    "type": "project",
+    "require": {
+        "efabrica/phpstan-config": "^0.22",
+        "efabrica/coding-standard": "^0.8"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
+    },
+    "minimum-stability": "stable"
+}

--- a/.github/phpstan/composer.lock
+++ b/.github/phpstan/composer.lock
@@ -1,0 +1,1000 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a7fb2eb92bf214a1d23252357684f93f",
+    "packages": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "efabrica/coding-standard",
+            "version": "0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/efabrica-team/coding-standard.git",
+                "reference": "6b59cd34f0472a3c35ce203bc15f653d24fb517e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/efabrica-team/coding-standard/zipball/6b59cd34f0472a3c35ce203bc15f653d24fb517e",
+                "reference": "6b59cd34f0472a3c35ce203bc15f653d24fb517e",
+                "shasum": ""
+            },
+            "require": {
+                "slevomat/coding-standard": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PSR2 based coding standard for PHP PHP_CodeSniffer",
+            "support": {
+                "issues": "https://github.com/efabrica-team/coding-standard/issues",
+                "source": "https://github.com/efabrica-team/coding-standard/tree/0.8.0"
+            },
+            "time": "2025-12-13T16:01:24+00:00"
+        },
+        {
+            "name": "efabrica/phpstan-config",
+            "version": "0.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/efabrica-team/efabrica-phpstan-config.git",
+                "reference": "086e2e4ffdc72094f4737cc9086b3f456b96ab45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/efabrica-team/efabrica-phpstan-config/zipball/086e2e4ffdc72094f4737cc9086b3f456b96ab45",
+                "reference": "086e2e4ffdc72094f4737cc9086b3f456b96ab45",
+                "shasum": ""
+            },
+            "require": {
+                "efabrica/phpstan-rules": "^0.8.1",
+                "pepakriz/phpstan-exception-rules": "^0.12",
+                "php": "^8.1",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-nette": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpstan/phpstan-symfony": "^1.3",
+                "phpstan/phpstan-webmozart-assert": "^1.0",
+                "sidz/phpstan-rules": "^0.4.5",
+                "spaze/phpstan-disallowed-calls": "^2.0"
+            },
+            "require-dev": {
+                "nette/database": "^3.2",
+                "phpunit/phpunit": "^9.5",
+                "tomaj/hermes": "^4.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStanConfig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Custom configs for PHPstan",
+            "keywords": [
+                "PHPStan",
+                "config"
+            ],
+            "support": {
+                "source": "https://github.com/efabrica-team/efabrica-phpstan-config/tree/0.22.0"
+            },
+            "time": "2026-02-04T13:23:01+00:00"
+        },
+        {
+            "name": "efabrica/phpstan-rules",
+            "version": "0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/efabrica-team/phpstan-rules.git",
+                "reference": "d9f684bd0e7f4833356fa577c07bb5e823b5cc0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/efabrica-team/phpstan-rules/zipball/d9f684bd0e7f4833356fa577c07bb5e823b5cc0e",
+                "reference": "d9f684bd0e7f4833356fa577c07bb5e823b5cc0e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.4 <8.5",
+                "phpstan/phpstan": "^1.8"
+            },
+            "require-dev": {
+                "efabrica/php-extensions-finder": "^0.5",
+                "guzzlehttp/guzzle": "^7.3",
+                "nette/di": "^2.3.0 || ^3.0.0",
+                "nikic/php-parser": "^4.14",
+                "phpunit/phpunit": "^9.5",
+                "tomaj/nette-api": "^3.0.0",
+                "tracy/tracy": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Efabrica\\PHPStanRules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "support": {
+                "issues": "https://github.com/efabrica-team/phpstan-rules/issues",
+                "source": "https://github.com/efabrica-team/phpstan-rules/tree/0.8.1"
+            },
+            "time": "2026-01-27T07:47:36+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.19.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
+                "reference": "51bd93cc741b7fc3d63d20b6bdcd99fdaa359837",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.5"
+            },
+            "time": "2025-12-06T11:45:25+00:00"
+        },
+        {
+            "name": "pepakriz/phpstan-exception-rules",
+            "version": "v0.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pepakriz/phpstan-exception-rules.git",
+                "reference": "c5f3fe501e5a6c57c33fb678ad9278131bc1b9bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pepakriz/phpstan-exception-rules/zipball/c5f3fe501e5a6c57c33fb678ad9278131bc1b9bd",
+                "reference": "c5f3fe501e5a6c57c33fb678ad9278131bc1b9bd",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.13",
+                "php": ">=7.1",
+                "phpstan/phpstan": "^1.0"
+            },
+            "require-dev": {
+                "nette/utils": "^3.0",
+                "php-parallel-lint/php-console-highlighter": "^0.4.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-nette": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^7.5.6 || ^9.4.2",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "~3.5.2"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pepakriz\\PHPStanExceptionRules\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Exception rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/pepakriz/phpstan-exception-rules/issues",
+                "source": "https://github.com/pepakriz/phpstan-exception-rules/tree/v0.12.0"
+            },
+            "time": "2021-11-07T19:03:56+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.33",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T20:30:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "reference": "f94d246cc143ec5a23da868f8f7e1393b50eaa82",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.1"
+            },
+            "time": "2024-09-11T15:52:35+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-nette",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-nette.git",
+                "reference": "bc74b8b208b47f163fe55708fcf1a0333247fa79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-nette/zipball/bc74b8b208b47f163fe55708fcf1a0333247fa79",
+                "reference": "bc74b8b208b47f163fe55708fcf1a0333247fa79",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11.11"
+            },
+            "conflict": {
+                "nette/application": "<2.3.0",
+                "nette/component-model": "<2.3.0",
+                "nette/di": "<2.3.0",
+                "nette/forms": "<2.3.0",
+                "nette/http": "<2.3.0",
+                "nette/utils": "<2.3.0"
+            },
+            "require-dev": {
+                "nette/application": "^3.0",
+                "nette/forms": "^3.0",
+                "nette/utils": "^2.3.0 || ^3.0.0",
+                "nikic/php-parser": "^4.13.2",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "~9.5.28"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Nette Framework class reflection extension for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-nette/issues",
+                "source": "https://github.com/phpstan/phpstan-nette/tree/1.3.8"
+            },
+            "time": "2024-08-25T12:11:12+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "b564ca479e7e735f750aaac4935af965572a7845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/b564ca479e7e735f750aaac4935af965572a7845",
+                "reference": "b564ca479e7e735f750aaac4935af965572a7845",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12.4"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.6.2"
+            },
+            "time": "2025-01-19T13:02:24+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-symfony",
+            "version": "1.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-symfony.git",
+                "reference": "18df9086a84fc28e9a231ea8e91d5aff1a0a3d6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/18df9086a84fc28e9a231ea8e91d5aff1a0a3d6f",
+                "reference": "18df9086a84fc28e9a231ea8e91d5aff1a0a3d6f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.3.11",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5",
+                "psr/container": "1.0 || 1.1.1",
+                "symfony/config": "^5.4 || ^6.1",
+                "symfony/console": "^5.4 || ^6.1",
+                "symfony/dependency-injection": "^5.4 || ^6.1",
+                "symfony/form": "^5.4 || ^6.1",
+                "symfony/framework-bundle": "^5.4 || ^6.1",
+                "symfony/http-foundation": "^5.4 || ^6.1",
+                "symfony/messenger": "^5.4",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/serializer": "^5.4",
+                "symfony/service-contracts": "^2.2.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukáš Unger",
+                    "email": "looky.msc@gmail.com",
+                    "homepage": "https://lookyman.net"
+                }
+            ],
+            "description": "Symfony Framework extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-symfony/issues",
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.4.16"
+            },
+            "time": "2025-09-07T06:55:28+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-webmozart-assert",
+            "version": "1.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-webmozart-assert.git",
+                "reference": "960dd44e8466191590dd0d7940d3e9496eebebbd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-webmozart-assert/zipball/960dd44e8466191590dd0d7940d3e9496eebebbd",
+                "reference": "960dd44e8466191590dd0d7940d3e9496eebebbd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
+                "phpunit/phpunit": "^9.5",
+                "webmozart/assert": "^1.11.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan webmozart/assert extension",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-webmozart-assert/issues",
+                "source": "https://github.com/phpstan/phpstan-webmozart-assert/tree/1.2.11"
+            },
+            "time": "2024-09-11T15:48:08+00:00"
+        },
+        {
+            "name": "sidz/phpstan-rules",
+            "version": "0.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sidz/phpstan-rules.git",
+                "reference": "17bf97643b7b3d4557e0a0c1c2d958fcceade4fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sidz/phpstan-rules/zipball/17bf97643b7b3d4557e0a0c1c2d958fcceade4fd",
+                "reference": "17bf97643b7b3d4557e0a0c1c2d958fcceade4fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1, <8.5",
+                "phpstan/phpstan": "^1.8"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.59",
+                "infection/infection": "^0.28.0",
+                "nikic/php-parser": "^4.14 || ^5.0",
+                "phpunit/phpunit": "^10.1"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sid\\PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oleg Zhulnev",
+                    "homepage": "https://github.com/sidz"
+                }
+            ],
+            "description": "Set of PHPStan rules",
+            "homepage": "https://github.com/sidz/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-magic-numbers",
+                "phpstan-rules"
+            ],
+            "support": {
+                "issues": "https://github.com/sidz/phpstan-rules/issues",
+                "source": "https://github.com/sidz/phpstan-rules"
+            },
+            "time": "2024-12-08T17:38:04+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.30.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "70a3b2150600122f87c59cae1c1b5902ba73798b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/70a3b2150600122f87c59cae1c1b5902ba73798b",
+                "reference": "70a3b2150600122f87c59cae1c1b5902ba73798b",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.3.2",
+                "squizlabs/php_codesniffer": "^4.0.1"
+            },
+            "require-dev": {
+                "phing/phing": "3.0.1|3.1.2",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.2.2",
+                "phpstan/phpstan-deprecation-rules": "2.0.4",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.30"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.30.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-27T11:26:35+00:00"
+        },
+        {
+            "name": "spaze/phpstan-disallowed-calls",
+            "version": "v2.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spaze/phpstan-disallowed-calls.git",
+                "reference": "1500f90ff6a705009731cc14e50d4faf2d202bf3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/1500f90ff6a705009731cc14e50d4faf2d202bf3",
+                "reference": "1500f90ff6a705009731cc14e50d4faf2d202bf3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "require-dev": {
+                "nette/neon": "^3.2",
+                "nikic/php-parser": "^4.13",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^8.5 || ^10.1",
+                "spaze/coding-standard": "^1.7",
+                "symfony/polyfill-php80": "^1.27"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spaze\\PHPStan\\Rules\\Disallowed\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michal Špaček",
+                    "email": "mail@michalspacek.cz",
+                    "homepage": "https://www.michalspacek.cz"
+                }
+            ],
+            "description": "PHPStan rules to detect disallowed method & function calls, constant, namespace & superglobal usages",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/spaze/phpstan-disallowed-calls/issues",
+                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.16.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spaze",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-10-28T15:29:27+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-10T16:43:36+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  tests:
+    name: PHPUnit (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.3', '8.4']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit tests
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install library dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install analysis tooling
+        run: composer install --no-interaction --no-progress --prefer-dist --working-dir=.github/phpstan
+
+      - name: Run PHPStan
+        run: php -d memory_limit=-1 .github/phpstan/vendor/bin/phpstan analyse -c .github/phpstan/vendor/efabrica/phpstan-config/conf/nette-lib/level.8.neon
+
+  phpcs:
+    name: Code style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install analysis tooling
+        run: composer install --no-interaction --no-progress --prefer-dist --working-dir=.github/phpstan
+
+      - name: Run PHPCS
+        run: php .github/phpstan/vendor/bin/phpcs src --standard=.github/phpstan/vendor/efabrica/coding-standard/eFabrica --extensions=php -n

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 bower_components
 tests/_output/*
 composer.lock
+!/.github/phpstan/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "nette/forms": "^3.1",
-        "latte/latte": "^2.11 || ^3.0"
+        "nette/forms": "^3.3",
+        "latte/latte": "^2.11 || ^3.1.4"
     },
     "config": {
         "platform": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,1 +1,5 @@
 parameters:
+    ignoreErrors:
+        -
+            message: '#.*#'
+            path: src/DI/NeoFormMacroSet.php

--- a/src/Build/AbstractForm.php
+++ b/src/Build/AbstractForm.php
@@ -24,6 +24,9 @@ abstract class AbstractForm extends ActiveRowForm
         $this->formFactory = $formFactory;
     }
 
+    /**
+     * @param iterable<array-key, mixed> $options
+     */
     public function create(?ActiveRow $row = null, iterable $options = []): NeoFormControl
     {
         $form = $this->formFactory->create();

--- a/src/Build/ActiveRowForm.php
+++ b/src/Build/ActiveRowForm.php
@@ -21,14 +21,16 @@ abstract class ActiveRowForm extends FormDefinition
     }
 
     /**
-     * @param ActiveRow $row
-     * @return array $form->setDefaults(...)
+     * @return array<string, mixed> $form->setDefaults(...)
      */
     protected function initFormData(ActiveRow $row): array
     {
         return $row->toArray();
     }
 
+    /**
+     * @param array<string, mixed> $values
+     */
     protected function onSuccess(NeoForm $form, array $values, ?ActiveRow $row = null): void
     {
         if ($row === null) {
@@ -38,10 +40,16 @@ abstract class ActiveRowForm extends FormDefinition
         }
     }
 
+    /**
+     * @param array<string, mixed> $values
+     */
     protected function onCreate(NeoForm $form, array $values): void
     {
     }
 
+    /**
+     * @param array<string, mixed> $values
+     */
     protected function onUpdate(NeoForm $form, array $values, ActiveRow $row): void
     {
     }

--- a/src/Build/FormDefinition.php
+++ b/src/Build/FormDefinition.php
@@ -15,6 +15,9 @@ abstract class FormDefinition
         return new NeoFormControl($form, fn(Template $template) => $this->template($template));
     }
 
+    /**
+     * @param array<string, mixed> $values
+     */
     protected function onSuccess(NeoForm $form, array $values): void
     {
     }

--- a/src/Build/NeoContainer.php
+++ b/src/Build/NeoContainer.php
@@ -5,6 +5,7 @@ namespace Efabrica\NeoForms\Build;
 use Efabrica\NeoForms\Control\ControlGroupBuilder;
 use Efabrica\NeoForms\Render\NeoFormRenderer;
 use Nette\Forms\Container;
+use Nette\Forms\ControlGroup;
 use Nette\Forms\Controls\BaseControl;
 use Nette\HtmlStringable;
 use Nette\Localization\Translator;
@@ -17,6 +18,9 @@ class NeoContainer extends Container
 {
     use NeoContainerTrait;
 
+    /**
+     * @var array<string, ControlGroup>
+     */
     private array $childGroups = [];
 
     private bool $singleRender = false;

--- a/src/Build/NeoContainerTrait.php
+++ b/src/Build/NeoContainerTrait.php
@@ -26,6 +26,9 @@ trait NeoContainerTrait
 {
     use DivTrait;
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $options = [];
 
     /**
@@ -36,6 +39,9 @@ trait NeoContainerTrait
         return $this->options[$name] ?? null;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOptions(): array
     {
         return $this->options;
@@ -74,6 +80,9 @@ trait NeoContainerTrait
         return $component;
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     public function addTags(string $name, Stringable|string|null $label = null, array $config = [], ?string $placeholder = null): Tags
     {
         $component = new Tags($label, $config, $placeholder);
@@ -81,6 +90,9 @@ trait NeoContainerTrait
         return $component;
     }
 
+    /**
+     * @param string[]|array{value: string}[] $choices
+     */
     public function addStaticTags(
         string $name,
         Stringable|string|null $label,
@@ -128,6 +140,9 @@ trait NeoContainerTrait
         return $component;
     }
 
+    /**
+     * @param (Closure(SubmitButton, array<array-key, mixed>|object): void)|null $onSubmit
+     */
     public function addSubmit(string $name, string|Stringable|null $caption = null, ?Closure $onSubmit = null): SubmitButton
     {
         $component = new SubmitButton($caption);
@@ -138,7 +153,7 @@ trait NeoContainerTrait
         return $component;
     }
 
-    public function addContainer($name, ?NeoContainer $container = null): NeoContainer
+    public function addContainer(int|string $name, ?NeoContainer $container = null): NeoContainer
     {
         $control = $container ?? new NeoContainer();
         $control->currentGroup = $this->currentGroup;

--- a/src/Build/NeoForm.php
+++ b/src/Build/NeoForm.php
@@ -25,10 +25,14 @@ class NeoForm extends Form
     use NeoContainerTrait;
 
     private bool $readonly = false;
+
     private bool $readonlyAttr = false;
 
     private ?NeoFormTemplate $template = null;
 
+    /**
+     * @var array<string, string>
+     */
     private static array $excludedKeys = [];
 
     /**
@@ -71,6 +75,9 @@ class NeoForm extends Form
         return $this;
     }
 
+    /**
+     * @param array<int|string, mixed> $redirectArgs
+     */
     public function finish(?string $flashMessage = null, ?string $redirect = 'default', array $redirectArgs = []): void
     {
         $presenter = $this->getPresenter();
@@ -111,6 +118,9 @@ class NeoForm extends Form
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $args
+     */
     public function withTemplate(string $templatePath, array $args = []): NeoFormControl
     {
         return new NeoFormControl($this, function (Template $template) use ($templatePath, $args) {
@@ -121,7 +131,10 @@ class NeoForm extends Form
         });
     }
 
-    public function getValues(string|object|bool|null $returnType = null, ?array $controls = null): object|array
+    /**
+     * @return array<string, mixed>|object
+     */
+    public function getValues(string|object|null $returnType = null, ?array $controls = null): object|array
     {
         $values = parent::getValues($returnType, $controls);
         self::removeExcludedKeys($values);
@@ -136,11 +149,11 @@ class NeoForm extends Form
     }
 
     /**
-     * @param iterable|object $values
-     * @return void
+     * @param iterable<array-key, mixed>|object $values
      */
     public static function removeExcludedKeys(iterable|object &$values): void
     {
+        // @phpstan-ignore-next-line foreach.nonIterable (plain objects, e.g. custom getValues() DTOs, are iterable over their public properties at runtime)
         foreach ($values as $key => &$value) {
             if (is_object($value) || is_array($value)) {
                 self::removeExcludedKeys($value);

--- a/src/Control/CodeEditor.php
+++ b/src/Control/CodeEditor.php
@@ -5,6 +5,7 @@ namespace Efabrica\NeoForms\Control;
 use Nette\Forms\Controls\TextArea;
 use Nette\Utils\Html;
 use Nette\Utils\Json;
+use Stringable;
 
 /**
  * Ace Code Editor
@@ -25,9 +26,8 @@ class CodeEditor extends TextArea
 
     /**
      * @param self::MODE_* $mode
-     * @param string|object $label
      */
-    public function __construct(string $mode, $label = null)
+    public function __construct(string $mode, string|Stringable|null $label = null)
     {
         parent::__construct($label);
         $this->mode = $mode;

--- a/src/Control/ControlGroupBuilder.php
+++ b/src/Control/ControlGroupBuilder.php
@@ -78,6 +78,7 @@ class ControlGroupBuilder
     }
 
     /**
+     * @param array<int, mixed> $arguments
      * @return mixed
      */
     public function __call(string $name, array $arguments = [])

--- a/src/Control/FormCollection.php
+++ b/src/Control/FormCollection.php
@@ -13,6 +13,7 @@ use Nette\Bridges\ApplicationLatte\TemplateFactory;
 use Nette\ComponentModel\IComponent;
 use Nette\ComponentModel\IContainer;
 use Nette\Forms\Controls\BaseControl;
+use Nette\Forms\Controls\HiddenField;
 use Nette\InvalidArgumentException;
 use Nette\Utils\ArrayHash;
 use Nette\Utils\Html;
@@ -39,6 +40,9 @@ class FormCollection extends NeoContainer
 
     private ?bool $simple = null;
 
+    /**
+     * @var array<string, mixed>|null
+     */
     private ?array $httpData = null;
 
     private int $requiredCount = 0;
@@ -56,6 +60,11 @@ class FormCollection extends NeoContainer
         if ($formFactory !== null) {
             $this->formFactory = Closure::fromCallable($formFactory);
         }
+        $this->prototype = $this->addCollectionItem('__prototype' . ++self::$prototypeIndex . '__', true);
+        $this->formFactory?->__invoke($this->prototype);
+        $prototypeName = $this->prototype->getName();
+        assert($prototypeName !== null);
+        NeoForm::addExcludedKeys(self::ORIGINAL_DATA, FormCollectionItem::UNIQID, $prototypeName);
     }
 
     public function addCssClass(string $class): self
@@ -63,19 +72,21 @@ class FormCollection extends NeoContainer
         $this->cssClass = $class;
         return $this;
     }
+
     public function setParent(?IContainer $parent, ?string $name = null): static
     {
         parent::setParent($parent, $name);
-        $this->prototype = $this->addCollectionItem('__prototype' . ++self::$prototypeIndex . '__', true);
-        $this->formFactory?->__invoke($this->prototype);
-        $this->addHidden(self::ORIGINAL_DATA, '{}');
-        NeoForm::addExcludedKeys(self::ORIGINAL_DATA, FormCollectionItem::UNIQID, $this->prototype->getName());
+        if ($this->getComponent(self::ORIGINAL_DATA, false) === null) {
+            $this->addHidden(self::ORIGINAL_DATA, '{}');
+        }
         return $this;
     }
 
     public function getDiff(): FormCollectionDiff
     {
-        return new FormCollectionDiff($this->getValues('array'));
+        $values = $this->getValues('array');
+        assert(is_array($values));
+        return new FormCollectionDiff($values);
     }
 
     public function getLabel(): string
@@ -120,16 +131,17 @@ class FormCollection extends NeoContainer
         $this->addComponent($this->prototype, $this->prototype->getName());
     }
 
-    public function setValues($values, bool $erase = false, bool $onlyDisabled = false): static
+    public function setValues(array|object $values, bool $erase = false, bool $onlyDisabled = false): static
     {
-        /** @var mixed $values */
-        if ($values === null || is_iterable($values)) {
+        if (is_iterable($values)) {
             $this->updateChildren($values);
         }
-        /** @var array|object $values */
         return parent::setValues($values, $erase);
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
     protected function getHttpData(): ?array
     {
         if ($this->httpData !== null) {
@@ -139,7 +151,7 @@ class FormCollection extends NeoContainer
             return null;
         }
 
-        /** @var array $httpData */
+        /** @var array<string, mixed> $httpData */
         $httpData = $this->getForm()->getHttpData();
         /** @var string $lookupPath */
         $lookupPath = $this->lookupPath(NeoForm::class);
@@ -150,6 +162,9 @@ class FormCollection extends NeoContainer
         return $httpData;
     }
 
+    /**
+     * @param iterable<array-key, mixed>|null $data
+     */
     public function updateChildren(?iterable $data = null): void
     {
         $data ??= $this->getHttpData();
@@ -169,7 +184,7 @@ class FormCollection extends NeoContainer
         foreach ($values as $key => $childValues) {
             if (!isset($components[$key])) {
                 $child = $this->addCollectionItem($key);
-                $this->formFactory->__invoke($child);
+                $this->formFactory?->__invoke($child);
                 $child->setValues($childValues);
             }
             unset($components[$key]);
@@ -214,6 +229,9 @@ class FormCollection extends NeoContainer
         $this->simple = $simple;
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     protected function renderTemplate(string $path, array $params): Html
     {
         $presenter = $this->getForm()->getPresenter();
@@ -247,8 +265,11 @@ class FormCollection extends NeoContainer
         }
 
         $originalArray = $this->getUntrustedValues('array');
+        assert(is_array($originalArray));
         unset($originalArray[self::ORIGINAL_DATA]);
-        $originalData = $this[self::ORIGINAL_DATA]->setValue(json_encode($originalArray, JSON_THROW_ON_ERROR));
+        $originalDataControl = $this->getComponent(self::ORIGINAL_DATA);
+        assert($originalDataControl instanceof HiddenField);
+        $originalData = $originalDataControl->setValue(json_encode($originalArray, JSON_THROW_ON_ERROR));
 
         return Html::el()
             ->addHtml($this->getLabelHtml())
@@ -319,7 +340,10 @@ class FormCollection extends NeoContainer
         return $item;
     }
 
-    public function getUntrustedValues($returnType = ArrayHash::class, ?array $controls = null): object|array
+    /**
+     * @return array<string, mixed>|object
+     */
+    public function getUntrustedValues(string|object|null $returnType = ArrayHash::class, ?array $controls = null): object|array
     {
         $this->removeComponent($this->prototype);
         $values = parent::getUntrustedValues($returnType, $controls);

--- a/src/Control/FormCollectionDiff.php
+++ b/src/Control/FormCollectionDiff.php
@@ -9,10 +9,19 @@ use RuntimeException;
 
 class FormCollectionDiff
 {
+    /**
+     * @var array<int|string, array<string, mixed>>
+     */
     private array $originalData;
 
+    /**
+     * @var array<int|string, array<string, mixed>>
+     */
     private array $newData;
 
+    /**
+     * @param array<int|string, mixed> $httpData
+     */
     public function __construct(array $httpData)
     {
         $originalData = $httpData[FormCollection::ORIGINAL_DATA] ?? null;
@@ -88,6 +97,10 @@ class FormCollectionDiff
         }
     }
 
+    /**
+     * @param array<array-key, mixed> $a
+     * @param array<array-key, mixed> $b
+     */
     protected function areArraysRecursivelyEqual(array $a, array $b): bool
     {
         if (count($a) !== count($b)) {
@@ -111,6 +124,10 @@ class FormCollectionDiff
         return true;
     }
 
+    /**
+     * @param array<array-key, mixed> $array
+     * @return array<array-key, mixed>
+     */
     public static function cleanArray(array $array): array
     {
         foreach ($array as $key => $value) {

--- a/src/Control/FormCollectionItem.php
+++ b/src/Control/FormCollectionItem.php
@@ -20,7 +20,10 @@ class FormCollectionItem extends NeoContainer
         }
     }
 
-    public function getUntrustedValues($returnType = ArrayHash::class, ?array $controls = null): object|array
+    /**
+     * @return array<string, mixed>|object
+     */
+    public function getUntrustedValues(string|object|null $returnType = ArrayHash::class, ?array $controls = null): object|array
     {
         if ($this->uniqId !== null && $this->uniqId->getParent() !== null && $this->uniqId->getValue() === '') {
             $this->removeComponent($this->uniqId);

--- a/src/Control/FormCollectionItemDiff.php
+++ b/src/Control/FormCollectionItemDiff.php
@@ -4,12 +4,25 @@ namespace Efabrica\NeoForms\Control;
 
 class FormCollectionItemDiff
 {
+    /**
+     * @var array<string, mixed>
+     */
     private array $oldRow;
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $newRow;
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $diff = [];
 
+    /**
+     * @param array<string, mixed> $oldRow
+     * @param array<string, mixed> $newRow
+     */
     public function __construct(array $oldRow, array $newRow)
     {
         foreach ($oldRow as $key => $oldValue) {
@@ -44,11 +57,17 @@ class FormCollectionItemDiff
         $this->newRow = FormCollectionDiff::cleanArray($newRow);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getOldRow(): array
     {
         return $this->oldRow;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getNewRow(): array
     {
         return $this->newRow;

--- a/src/Control/SelectBoxTrait.php
+++ b/src/Control/SelectBoxTrait.php
@@ -6,10 +6,14 @@ use Stringable;
 
 trait SelectBoxTrait
 {
+    /**
+     * @var array<int|string, mixed>
+     */
     private array $itemTree = [];
 
     /**
      * @param string|Stringable|null $label
+     * @param array<int|string, mixed>|null $items
      */
     public function __construct(string|Stringable|null $label = null, ?array $items = null)
     {
@@ -19,6 +23,9 @@ trait SelectBoxTrait
         parent::__construct($label, $items);
     }
 
+    /**
+     * @param array<int|string, mixed> $items
+     */
     public function setItems(array $items, bool $useKeys = true): self
     {
         $this->itemTree = $items;
@@ -28,6 +35,9 @@ trait SelectBoxTrait
         return parent::setItems($items, $useKeys);
     }
 
+    /**
+     * @return array<int|string, mixed>
+     */
     public function getItems(bool $tree = false): array
     {
         if ($tree) {

--- a/src/Control/StaticTags.php
+++ b/src/Control/StaticTags.php
@@ -25,14 +25,18 @@ class StaticTags extends Tags
         );
     }
 
+    /**
+     * @param string[]|array{value: string}[] $choices
+     * @return array{value: string}[]
+     */
     public static function formatChoices(array $choices): array
     {
-        if (is_string($choices[0] ?? null)) {
-            return array_map(static fn($c) => ['value' => $c], $choices);
-        }
-        return $choices;
+        return array_map(static fn($c) => is_string($c) ? ['value' => $c] : $c, $choices);
     }
 
+    /**
+     * @param string[]|array{value: string}[] $choices
+     */
     public function setSelectedChoices(array $choices): self
     {
         $choices = self::formatChoices($choices);

--- a/src/Control/SubmitButton.php
+++ b/src/Control/SubmitButton.php
@@ -2,7 +2,9 @@
 
 namespace Efabrica\NeoForms\Control;
 
-class SubmitButton extends \Nette\Forms\Controls\SubmitButton
+use Nette\Forms\Controls\SubmitButton as NetteSubmitButton;
+
+class SubmitButton extends NetteSubmitButton
 {
     public function setIcon(?string $icon): self
     {

--- a/src/Control/Tags.php
+++ b/src/Control/Tags.php
@@ -11,12 +11,18 @@ use Nette\Utils\Json;
  */
 class Tags extends TextInput
 {
+    /**
+     * @var array<string, mixed>
+     */
     private array $config;
 
     private ?string $placeholder;
 
     private bool $sortable = false;
 
+    /**
+     * @param array<string, mixed> $config
+     */
     public function __construct(?string $label = null, array $config = [], ?string $placeholder = null)
     {
         parent::__construct($label);
@@ -24,6 +30,9 @@ class Tags extends TextInput
         $this->placeholder = $placeholder;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getTagsConfig(): array
     {
         return $this->config;
@@ -54,6 +63,9 @@ class Tags extends TextInput
         return $control;
     }
 
+    /**
+     * @return array<int, string>
+     */
     public static function getTagValues(?string $json): array
     {
         if ($json === null || trim($json) === '') {

--- a/src/Render/NeoFormRenderer.php
+++ b/src/Render/NeoFormRenderer.php
@@ -4,6 +4,7 @@ namespace Efabrica\NeoForms\Render;
 
 use Efabrica\NeoForms\Build\NeoContainer;
 use Efabrica\NeoForms\Build\NeoForm;
+use Efabrica\NeoForms\Control\SubmitButton as NeoSubmitButton;
 use Efabrica\NeoForms\Render\Template\NeoFormTemplate;
 use Generator;
 use Nette\ComponentModel\Component;
@@ -43,32 +44,35 @@ class NeoFormRenderer
             $this->defaultTemplate;
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function form(NeoForm $form, array $attrs = []): Generator
     {
         $form->fireRenderEvents();
 
         $this->isReadonly =
-            $attrs["readonly"] ??
+            $attrs['readonly'] ??
             $form->isReadonly() || $form->isReadonlyAttr();
 
         foreach ($form->getComponentTree() as $control) {
             if (!$control instanceof BaseControl) {
                 continue;
             }
-            $control->setOption("rendered", false);
+            $control->setOption('rendered', false);
             if ($this->isReadonly) {
                 $control->setOption(
-                    "readonly",
-                    $control->getOption("readonly") ?? true,
+                    'readonly',
+                    $control->getOption('readonly') ?? true,
                 );
             }
         }
 
-        $showErrors = $attrs["formErrors"] ?? true;
+        $showErrors = $attrs['formErrors'] ?? true;
         $formErrors = $showErrors
             ? $this->template($form)->formErrors($form->getOwnErrors())
             : Html::el();
-        unset($attrs["formErrors"]);
+        unset($attrs['formErrors']);
 
         $generator = $this->template($form)->form(
             $this,
@@ -83,7 +87,7 @@ class NeoFormRenderer
     public function formGroup(NeoForm $form, ControlGroup $group): Html
     {
         $body = Html::el();
-        $children = $group->getOption("children");
+        $children = $group->getOption('children');
         if (is_iterable($children)) {
             foreach ($children as $child) {
                 if ($child instanceof ControlGroup) {
@@ -92,8 +96,7 @@ class NeoFormRenderer
             }
         }
         foreach ($this->getGroupControls($group) as $control) {
-            if (
-                $control instanceof BaseControl ||
+            if ($control instanceof BaseControl ||
                 $control instanceof Container
             ) {
                 if (!$this->isRendered($control)) {
@@ -102,11 +105,11 @@ class NeoFormRenderer
             }
         }
 
-        if (trim($body->getHtml()) === "") {
+        if (trim($body->getHtml()) === '') {
             return Html::el();
         }
 
-        $label = $group->getOption("label");
+        $label = $group->getOption('label');
         if (is_string($label)) {
             $label = $this->translator->translate($label);
         }
@@ -114,7 +117,7 @@ class NeoFormRenderer
             $label = null;
         }
 
-        $attrs = $group->getOption("attrs") ?? [];
+        $attrs = $group->getOption('attrs') ?? [];
         return $this->template($form)->formGroup(
             $label,
             $body,
@@ -124,6 +127,7 @@ class NeoFormRenderer
 
     /**
      * @param BaseControl|Container $el
+     * @param array<string, mixed> $attrs
      */
     public function formRow($el, array $attrs = []): Html
     {
@@ -135,11 +139,11 @@ class NeoFormRenderer
             return Html::el();
         }
 
-        $inputAttrs = $attrs["input"] ?? [];
-        unset($attrs["input"]);
+        $inputAttrs = $attrs['input'] ?? [];
+        unset($attrs['input']);
 
-        if ($attrs["readonly"] ?? false) {
-            $inputAttrs["readonly"] = $attrs["readonly"];
+        if ($attrs['readonly'] ?? false) {
+            $inputAttrs['readonly'] = $attrs['readonly'];
         }
 
         if ($el instanceof HiddenField) {
@@ -158,53 +162,60 @@ class NeoFormRenderer
         );
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function formInput(BaseControl $el, array $attrs = []): Html
     {
-        if (
-            ($attrs["readonly"] ?? (bool) $el->getOption("readonly")) ||
-            $el->getForm()->isReadonlyAttr()
+        $form = $el->getForm();
+        assert($form instanceof NeoForm);
+
+        if (($attrs['readonly'] ?? (bool) $el->getOption('readonly')) ||
+            $form->isReadonlyAttr()
         ) {
-            $el->setAttribute("readonly", true);
+            $el->setAttribute('readonly', true);
         }
 
-        if ($el->getForm()->isReadonly()) {
-            return $this->template($el->getForm())->readonly($el);
+        if ($form->isReadonly()) {
+            return $this->template($form)->readonly($el);
         }
 
-        if (is_string($attrs["placeholder"] ?? null)) {
-            $attrs["placeholder"] = $this->translator->translate(
-                $attrs["placeholder"],
+        if (is_string($attrs['placeholder'] ?? null)) {
+            $attrs['placeholder'] = $this->translator->translate(
+                $attrs['placeholder'],
             );
         }
 
         /** Hotfix as SubmitButton does not have the correct type */
-        if (
-            $el instanceof SubmitButton &&
-            !$el instanceof \Efabrica\NeoForms\Control\SubmitButton
+        if ($el instanceof SubmitButton &&
+            !$el instanceof NeoSubmitButton
         ) {
-            $el->setOption("type", null);
+            $el->setOption('type', null);
         }
 
-        $description = $el->getOption("description");
+        $description = $el->getOption('description');
         if (is_string($description)) {
-            $descriptionEl = $this->template($el->getForm())->description(
+            $descriptionEl = $this->template($form)->description(
                 $description,
             );
         } elseif ($description instanceof Html) {
             $descriptionEl = $description;
         }
-        return $this->template($el->getForm())->formInput(
+        return $this->template($form)->formInput(
             $el,
             $attrs,
             $descriptionEl ?? Html::el(),
         );
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function formRest(NeoForm $form, array $options = []): Html
     {
         $groups = [];
         foreach ($form->getGroups() as $key => $group) {
-            $group->setOption("label", $group->getOption("label") ?? $key);
+            $group->setOption('label', $group->getOption('label') ?? $key);
             $groups[$key] = $this->formGroup($form, $group);
         }
 
@@ -215,23 +226,24 @@ class NeoFormRenderer
                 continue;
             }
             if (!$component instanceof Button) {
-                if (
-                    $component instanceof BaseControl ||
+                if ($component instanceof BaseControl ||
                     $component instanceof Container
                 ) {
                     $body->addHtml($this->formRow($component));
                 }
-            } elseif ($options["buttons"] ?? true) {
+            } elseif ($options['buttons'] ?? true) {
                 $buttons[] = $this->formRow($component);
             }
         }
         return $this->template($form)->formRest($body, $groups, $buttons);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function formLabel(BaseControl $el, array $attrs = []): Html
     {
-        if (
-            $el instanceof Button ||
+        if ($el instanceof Button ||
             $el instanceof HiddenField ||
             $el instanceof Checkbox
         ) {
@@ -240,14 +252,14 @@ class NeoFormRenderer
 
         /** @var string|null $caption */
         $caption = $el->getCaption();
-        if ($caption === null || $caption === "") {
+        if ($caption === null || $caption === '') {
             return Html::el();
         }
 
-        if (is_string($el->getOption("info"))) {
+        if (is_string($el->getOption('info'))) {
             $el->setOption(
-                "info",
-                $this->translator->translate($el->getOption("info")),
+                'info',
+                $this->translator->translate($el->getOption('info')),
             );
         }
 
@@ -266,7 +278,7 @@ class NeoFormRenderer
         }
         throw new RuntimeException(
             get_class($el) .
-                " is not supported in NeoFormRenderer for rendering errors",
+                ' is not supported in NeoFormRenderer for rendering errors',
         );
     }
 
@@ -280,8 +292,7 @@ class NeoFormRenderer
         }
         $rows = Html::el();
         foreach ($el->getComponents() as $component) {
-            if (
-                $component instanceof BaseControl ||
+            if ($component instanceof BaseControl ||
                 $component instanceof Container
             ) {
                 $rows->addHtml($this->formRow($component));
@@ -328,16 +339,13 @@ class NeoFormRenderer
     private function isRendered(IComponent $control): bool
     {
         if ($control instanceof BaseControl) {
-            return $control->getOption("rendered") === true;
+            return $control->getOption('rendered') === true;
         }
         if ($control instanceof NeoContainer && $control->isSingleRender()) {
-            $components = $control->getComponents();
-            if (is_array($components)) {
-                $first = reset($components);
-            } else {
-                $first = $control->getComponents()->current();
+            foreach ($control->getComponents() as $first) {
+                return $this->isRendered($first);
             }
-            return $this->isRendered($first);
+            return false;
         }
         return false;
     }

--- a/src/Render/Template/NeoFormTemplate.php
+++ b/src/Render/Template/NeoFormTemplate.php
@@ -26,6 +26,9 @@ use RadekDostal\NetteComponents\DateTimePicker\AbstractDateTimePicker;
 
 class NeoFormTemplate
 {
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function form(NeoFormRenderer $renderer, NeoForm $form, Html $errors, array $attrs): Generator
     {
         $renderRest = $attrs['rest'] ?? true;
@@ -34,6 +37,9 @@ class NeoFormTemplate
         return $this->applyAttrs($el, $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function formRow(Html $label, Html $input, Html $errors, array $attrs): Html
     {
         return $this->applyAttrs(Html::el('div')->addHtml($label . $input . $errors), $attrs);
@@ -41,6 +47,7 @@ class NeoFormTemplate
 
     /**
      * @param string|HtmlStringable|null $label
+     * @param array<string, mixed> $attrs
      */
     public function formGroup($label, Html $body, array $attrs): Html
     {
@@ -61,10 +68,8 @@ class NeoFormTemplate
     }
 
     /**
-     * @param Html   $body
      * @param Html[] $groups
-     * @param array  $buttons
-     * @return Html
+     * @param Html[] $buttons
      */
     public function formRest(Html $body, array $groups, array $buttons): Html
     {
@@ -92,11 +97,17 @@ class NeoFormTemplate
         return $el;
     }
 
+    /**
+     * @param (string|HtmlStringable)[] $errors
+     */
     public function rowErrors(array $errors): Html
     {
         return $this->formErrors($errors);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function formLabel(BaseControl $control, array $attrs): Html
     {
         $el = $control->getLabel();
@@ -117,6 +128,9 @@ class NeoFormTemplate
         return Html::el('div')->class('form-text')->setHtml($description);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function formInput(BaseControl $control, array $attrs, Html $description): Html
     {
         return Html::el()
@@ -125,6 +139,9 @@ class NeoFormTemplate
         ;
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function control(BaseControl $control, array $attrs): Html
     {
         $attrs += $control->getOptions();
@@ -168,57 +185,90 @@ class NeoFormTemplate
         return $control->getControl();
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function checkbox(Checkbox $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function datepicker(AbstractDateTimePicker $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function select(SelectBox $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function multiSelect(MultiSelectBox $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function button(Button $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function textarea(TextArea $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function hidden(HiddenField $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function upload(UploadControl $control, array $attrs): Html
     {
         /** @var TextBase $control */
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function radio(RadioList $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function checkboxList(CheckboxList $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     protected function textInput(TextInput $control, array $attrs): Html
     {
         return $this->applyAttrs($control->getControl(), $attrs);
@@ -251,6 +301,9 @@ class NeoFormTemplate
         return Html::fromText('(?)');
     }
 
+    /**
+     * @param array<string, mixed> $attrs
+     */
     public function applyAttrs(Html $el, array $attrs): Html
     {
         foreach ($attrs as $key => $value) {
@@ -268,6 +321,9 @@ class NeoFormTemplate
         return $el;
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function toggleSwitch(ToggleSwitch $control, array $params): Html
     {
         return $this->checkbox($control, $params);

--- a/tests/Control/FormCollectionTest.php
+++ b/tests/Control/FormCollectionTest.php
@@ -63,7 +63,7 @@ class FormCollectionTest extends TestCase
         foreach ($collection->getComponents() as $component) {
             $this->assertInstanceOf(FormCollectionItem::class, $component);
         }
-        $this->assertCount(1, $collection->getControls());
+        $this->assertCount(1, iterator_to_array($collection->getControls()));
         foreach ($collection->getControls() as $control) {
             $this->assertEquals('foo', $control->getName());
             $this->assertEquals('bar', $control->getValue());


### PR DESCRIPTION
## Summary
- Bumps `nette/forms` to `^3.3` and `latte/latte` to `^3.1.4` to fix a real version mismatch (`NeoFormNode::$tagRanges` didn't exist in the previously required range).
- Fixes a real `FormCollection` prototype lifecycle bug (prototype was built in `setParent()` instead of the constructor) and two real crash risks in `NeoFormRenderer` (a nullable `Form|null` from `getForm()` on the readonly-check path, and an `is_array()`/`Iterator::current()` branch in `isRendered()` that would fatal on a plain array).
- Adds missing generic array types (`array<string, mixed>` etc.) across `Build/`, `Control/`, and `Render/` to satisfy PHPStan level 8.
- Ignores the legacy Latte 2.x macro file (`src/DI/NeoFormMacroSet.php`, incompatible with Latte 3's Node-based API) in `phpstan.neon`.
- Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs PHPUnit (PHP 8.3 & 8.4), PHPStan level 8, and the eFabrica coding standard on every push/PR. The analysis tooling lives in an isolated Composer project under `.github/phpstan` so it doesn't pollute the library's own dependency tree (mirrors how the org's Docker-based tooling keeps phpstan/phpcs in a separate vendor tree).

## Test plan
- [x] `vendor/bin/phpunit tests` — 28 tests, 66 assertions, passing on PHP 8.3 and 8.4
- [x] PHPStan level 8 — 0 errors
- [x] `phpcs` against the eFabrica standard — 0 errors, 0 warnings
- [ ] CI run on this PR (will show once opened)